### PR TITLE
Use numeric UID in USER (Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --chown=app:app core/      core/
 COPY --chown=app:app static/    static/
 COPY --chown=app:app templates/ templates/
 COPY --chown=app:app app.py     .
-USER app
+USER 1000
 EXPOSE 4653
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
     CMD ["wget", "--spider", "-q", "-T", "2", "http://127.0.0.1:4653/api/2p/status"]


### PR DESCRIPTION
Switches `USER app` to `USER 1000` in the Dockerfile. Hadolint's DL3066 flags symbolic usernames because they aren't guaranteed to resolve on the host (e.g. Kubernetes `runAsNonRoot`); the account is already created with `-u 1000`, so this is a no-op at runtime.

Addresses code scanning alert #6.